### PR TITLE
Onnxruntime 1.14.2

### DIFF
--- a/build-macos.sh
+++ b/build-macos.sh
@@ -2,14 +2,14 @@
 
 echo "building for $(python --version)"
 
-version_tag="v1.15.0"
+version_tag="v1.14.2"
 onnxruntime_dir="onnxruntime"
 
 # cleanup
 rm -rf $onnxruntime_dir
 
 # download
-git clone --recurse-submodules --shallow-submodules --depth 1 --branch $version_tag https://github.com/microsoft/onnxruntime.git $onnxruntime_dir
+git clone https://github.com/verback2308/onnxruntime.git --recurse-submodules --shallow-submodules --depth 1 --branch rel-1.14.2 $onnxruntime_dir
 
 root_dir=$(pwd)
 dist_dir="$root_dir/dist"


### PR DESCRIPTION
An unofficial fork onnxruntime 1.14.1 with memory leak fixes and build improvements for M1/M2 chips.
Up to 1.14.1 (including) builds had a memory leak issue, which was fixed in the next version. But starting from 1.15.0, they have some graphic glitches and library is not suitable at all. [https://github.com/s0md3v/roop/issues/321#issuecomment-1585507301](https://github.com/cansik/onnxruntime-silicon/pull/url)

@cansik 

PR was re-created due to a typo in a branch name in the previous ones #5 