### PR TITLE
Fixed ORT build failure on macOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .idea
 venv*
+env*
 onnxruntime
 ie_build
 .DS_Store

--- a/build-macos.sh
+++ b/build-macos.sh
@@ -20,7 +20,15 @@ pip install -r requirements-dev.txt
 
 # build
 ./build.sh --clean
-./build.sh --skip-keras-test --skip_tests --config "Release" --parallel 8 --enable_pybind --build_wheel --wheel_name_suffix=-silicon --osx_arch "arm64" --apple_deploy_target 11 --use_coreml
+./build.sh --config Release \
+    --parallel \
+    --compile_no_warning_as_error \
+    --skip_submodule_sync \
+    --osx_arch "arm64" \
+    --use_coreml \
+    --build_wheel \
+    --wheel_name_suffix="-silicon" \
+    --skip_tests
 
 # copy to dist
 mkdir -p "$dist_dir"

--- a/build-macos.sh
+++ b/build-macos.sh
@@ -13,13 +13,25 @@ git clone --recurse-submodules --shallow-submodules --depth 1 --branch $version_
 
 root_dir=$(pwd)
 dist_dir="$root_dir/dist"
+patch_dir="$root_dir/patches"
 
 pushd "$root_dir/$onnxruntime_dir" || exit
+
 # install dependencies
 pip install -r requirements-dev.txt
 
-# build
+# cmake generate to download dependencies
 ./build.sh --clean
+./build.sh --update \
+    --config Release \
+    --parallel \
+    --skip_tests
+
+# apply patches
+echo "applying patches..."
+patch -i "$patch_dir/flatbuffers.patch" "./build/MacOS/Release/_deps/flatbuffers-src/src/idl_gen_rust.cpp"
+
+# build
 ./build.sh --config Release \
     --parallel \
     --compile_no_warning_as_error \
@@ -29,6 +41,16 @@ pip install -r requirements-dev.txt
     --build_wheel \
     --wheel_name_suffix="-silicon" \
     --skip_tests
+
+# check for errors in build
+RESULT=$?
+if [ $RESULT -ne 0 ]; then
+    echo "Error while building, please check the log."
+    exit $RESULT
+fi
+
+# wait for file to be copied
+sleep 1
 
 # copy to dist
 mkdir -p "$dist_dir"

--- a/patches/flatbuffers.patch
+++ b/patches/flatbuffers.patch
@@ -1,0 +1,20 @@
+--- idl_gen_rust_orig.cpp	2023-08-08 20:18:59
++++ idl_gen_rust.cpp	2023-08-08 20:21:13
+@@ -406,7 +406,7 @@
+     // example: f(A, D::E)          -> super::D::E
+     // does not include leaf object (typically a struct type).
+ 
+-    size_t i = 0;
++    // size_t i = 0;
+     std::stringstream stream;
+ 
+     auto s = src->components.begin();
+@@ -417,7 +417,7 @@
+       if (*s != *d) { break; }
+       ++s;
+       ++d;
+-      ++i;
++      // ++i;
+     }
+ 
+     for (; s != src->components.end(); ++s) { stream << "super::"; }


### PR DESCRIPTION
This PR fix the build failure of ORT on macOS Ventura using a MacBook Pro M1.

I basically started with the official [build instructions](https://onnxruntime.ai/docs/build/inferencing.html#macos) for macOS and I added two flags to enable CoreML support and the Python wheel creation: `--use_coreml` and `--build_wheel`. Contrary to what the [documentation](https://onnxruntime.ai/docs/build/eps.html#coreml) suggests, I removed `--minimal_build` that seemed to cause issues during compilation. I also removed the `--build_shared_lib`  flag since I don't think that's useful for the Python wheel build.

This seems to work well and the wheel size is similar to the ones that you released in the past (around 6.6MB).

This solves #8.