### PR TITLE
Improvements

### DIFF
--- a/build-macos.sh
+++ b/build-macos.sh
@@ -25,7 +25,7 @@ options:
     -h,--help		show this help message and exit
     -v,--version	shows onxruntime version
     --no-clean		suppresses resetting / cleaning and updating the repo,
-                        therefore try avoiding full rebuild
+			therefore try avoiding full rebuild
 
     --ninja		use ninja as build tool (sets corresponding CMake generator)
     --lto		enable LTO (expect slower build times).


### PR DESCRIPTION
# Improvements

## ditch `rm -rf`

I was genuinely embarrassed by its effects, so it inspired me for this PR :)

## options

the following options implemented:

`--no-clean` - suppresses everything but the last `./build.sh` invocation.
`--ninja` - sets `Ninja` as `CMake` generator. ninja outperforms gnumake at incremental compilation, above all.
`--lto` - may or may not result in measurable runtime performance gains, and WILL result in build performance loss, so this switch I consider experimental


## test

System info:

```shell
airstation:tmp ic$ nix-shell -p nix-info --run "nix-info -m"
 - system: `"aarch64-darwin"`
 - host os: `Darwin 23.2.0, macOS 14.2.1`
 - multi-user?: `yes`
 - sandbox: `no`
 - version: `nix-env (Nix) 2.19.2`
 - channels(root): `"nixpkgs"`
 - nixpkgs: `/nix/var/nix/profiles/per-user/root/channels/nixpkgs`

airstation:tmp ic$  nix-instantiate --eval '<nixpkgs>' --attr lib.version
"24.05pre561758.d6863cbcbbb8"
```

### build env + build/install

```shell
#/bin/bash

pyver=3.1

# no Xcode needed
# llvmPackages_latest pulls clang 16.0.6
nix-shell -p \
      micromamba \
      llvmPackages_latest.stdenv \ 
      cmake \
      ninja \
      iconv \
      darwin.apple_sdk.frameworks.Foundation \
      darwin.apple_sdk.frameworks.CoreML

alias m=micromamba

eval "$(m shell hook --shell bash)"

m env create -n onnx-rt
m activate onnx-rt
m install python=$pyver
pip install -U pip wheel

./build-mac.sh --lto --ninja

pip install dist/*.whl
```

### roadmap [maybe]

* linking using lld
* nix flake for build env
